### PR TITLE
Fix translation

### DIFF
--- a/docs/xamarin-forms/user-interface/picker/index.md
+++ b/docs/xamarin-forms/user-interface/picker/index.md
@@ -1,5 +1,5 @@
 ---
-title: Xamarin.FormsEmoji
+title: Xamarin.Forms Sélecteur
 description: Le Xamarin.Forms Sélecteur affiche une liste succincte d’éléments, à partir desquels l’utilisateur peut sélectionner un élément. Cet article explique comment utiliser la classe Picker pour sélectionner un élément de texte dans une liste de données.
 ms.prod: xamarin
 ms.assetid: D4815A4B-104B-4294-951B-BD8F2EC33C86


### PR DESCRIPTION
The page title for the picker control was Xamarin.FormsEmoji, the correct translation, used in the rest of the page, is "sélecteur".
